### PR TITLE
fix(no-alias-methods): reverse toThrow/toThrowError alias direction

### DIFF
--- a/src/rules/no-alias-methods.ts
+++ b/src/rules/no-alias-methods.ts
@@ -37,7 +37,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
       toReturnWith: 'toHaveReturnedWith',
       lastReturnedWith: 'toHaveLastReturnedWith',
       nthReturnedWith: 'toHaveNthReturnedWith',
-      toThrow: 'toThrowError',
+      toThrowError: 'toThrow',
     }
 
     return {

--- a/tests/no-alias-methods.test.ts
+++ b/tests/no-alias-methods.test.ts
@@ -13,7 +13,7 @@ ruleTester.run(rule.name, rule, {
     'expect(a).toHaveReturnedWith()',
     'expect(a).toHaveLastReturnedWith()',
     'expect(a).toHaveNthReturnedWith()',
-    'expect(a).toThrowError()',
+    'expect(a).toThrow()',
     'expect(a).rejects;',
     'expect(a);',
   ],
@@ -49,14 +49,14 @@ ruleTester.run(rule.name, rule, {
       ],
     },
     {
-      code: 'expect(a).not["toThrow"]()',
-      output: "expect(a).not['toThrowError']()",
+      code: 'expect(a).not["toThrowError"]()',
+      output: "expect(a).not['toThrow']()",
       errors: [
         {
           messageId: 'noAliasMethods',
           data: {
-            alias: 'toThrow',
-            canonical: 'toThrowError',
+            alias: 'toThrowError',
+            canonical: 'toThrow',
           },
           column: 15,
           line: 1,


### PR DESCRIPTION
Fixes #879.

Vitest deprecated `toThrowError` in favor of `toThrow`, but the previous mapping treated `toThrow` as the alias (→ `toThrowError`), causing a conflict where users got either a Vitest deprecation warning or a lint error.

This reverses the mapping so `toThrowError` is the alias and `toThrow` is the canonical name.